### PR TITLE
Removed optional parameter from lstat

### DIFF
--- a/types/mz/fs.d.ts
+++ b/types/mz/fs.d.ts
@@ -142,7 +142,7 @@ export function stat(path: string | Buffer): Promise<fs.Stats>;
  * `lstat()` is identical to `stat()`, except that if path is a symbolic link, then the link itself
  * is stat-ed, not the file that it refers to.
  */
-export function lstat(path: string | Buffer, callback?: (err: NodeJS.ErrnoException, stats: fs.Stats) => any): void;
+export function lstat(path: string | Buffer, callback: (err: NodeJS.ErrnoException, stats: fs.Stats) => any): void;
 
 /**
  * Asynchronous `lstat(2)`.


### PR DESCRIPTION
The optional flag on the callback version of lstat causes tsc to complain about using as promise. It always assumes to first variant which does not return a Promise.

You can see the `stat` and `fstat` have it removed. I am very confident this is the intended behaviour, and the optional flag is a copy-paste typo.

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: The other definitions in the package. It is clearly a topo